### PR TITLE
Symfony/yaml requirements updated to 2.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.2.0",
         "illuminate/support": "~5.0",
-        "symfony/yaml": "2.4.*"
+        "symfony/yaml": "2.6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
When I use with lumen 5.0.10, can't install because of symfony/yaml version.
lumen install symfony/yaml v2.6.*, but Parser requires v2.4.*
I uploaded my composer.json, composer.lock and composer error message to gist.
https://gist.github.com/artn/de58e6129a663dec7aa6 .