### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "~5.0",
-        "symfony/yaml": "2.6.*"
+        "symfony/yaml": "2.7.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
Laravel 5.1 is now using `symfony/yaml` version 2.7.x (currently 2.7.1). Update the compatibility for Laravel 5.1.