### PR TITLE
Updates For Encoder Changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,27 @@ matrix:
     - php: 7.0
   include:
     - php: 5.4
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+      env: 'BSON=0 MSGPACK=0 COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+
+env:
+  - 'BSON=0 MSGPACK=0'
+  - 'BSON=0 MSGPACK=1'
+  - 'BSON=mongo MSGPACK=0'
+  - 'BSON=mongodb MSGPACK=0'
+  - 'BSON=mongodb MSGPACK=1'
 
 before_script:
+  - sh -c "if [ $MSGPACK -eq 1 -a $(phpenv version-name) \< 7.0 ]; then wget https://github.com/msgpack/msgpack-php/archive/php5.zip -O php-msgpack.zip && unzip php-msgpack.zip && mv msgpack-php-php5 msgpack-php; fi"
+  - sh -c "if [ $MSGPACK -eq 1 -a $(phpenv version-name) \> 6.0 ]; then wget https://github.com/msgpack/msgpack-php/archive/master.zip -O php-msgpack.zip && unzip php-msgpack.zip && mv msgpack-php-master msgpack-php; fi"
+  - sh -c "if [ $MSGPACK -eq 1 ]; then cd msgpack-php/ && phpize && ./configure && make && make install; fi"
+  - sh -c "if [ $MSGPACK -eq 1 ]; then echo \"extension=msgpack.so\" >> `php --ini | grep \"Loaded Configuration\" | sed -e \"s|.*:\s*||\"`; fi"
+  - sh -c "if [ $MSGPACK -eq 0 ]; then echo \"Not Installing MSGPack Extension\"; fi"
+  - sh -c "if [ $BSON = mongo -a $(phpenv version-name) \< 7.0 ]; then wget https://github.com/mongodb/mongo-php-driver-legacy/archive/master.zip -O php-mongo.zip && unzip php-mongo.zip; fi"
+  - sh -c "if [ $BSON = mongo -a $(phpenv version-name) \< 7.0 ]; then cd mongo-php-driver-legacy-master/ && phpize && ./configure && make && make install; fi"
+  - sh -c "if [ $BSON = mongo -a $(phpenv version-name) \< 7.0 ]; then echo \"extension=mongo.so\" >> `php --ini | grep \"Loaded Configuration\" | sed -e \"s|.*:\s*||\"`; fi"
+  - sh -c "if [ $BSON = mongodb ]; then git clone --depth=50 --recursive https://github.com/mongodb/mongo-php-driver/; fi"
+  - sh -c "if [ $BSON = mongodb ]; then cd mongo-php-driver/ && git submodule status --recursive && ./.travis.scripts/compile.sh; fi"
+  - sh -c "if [ $BSON = 0 ]; then echo \"Not Installing Mongo or MongoDB Extension\"; fi"
   - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 

--- a/src/Facades/Parser.php
+++ b/src/Facades/Parser.php
@@ -18,8 +18,5 @@ class Parser extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor()
-    {
-        return 'Parser';
-    }
+    protected static function getFacadeAccessor() { return 'Parser'; }
 }

--- a/src/Formats/BSON.php
+++ b/src/Formats/BSON.php
@@ -19,22 +19,37 @@ class BSON implements FormatInterface
      * @param string $payload
      *
      * @throws ParserException
-     * @return array
      *
+     * @return array
      */
     public function parse($payload)
     {
-        if (function_exists('bson_decode')) {
-            if ($payload) {
-                $bson = bson_decode(trim($payload));
-                if ( ! $bson) {
-                    throw new ParserException('Failed To Parse BSON');
-                }
-                return $bson;
-            }
-            return [];
+        if (function_exists('MongoDB\BSON\toPHP') && ! function_exists('bson_decode')) {
+            require_once(__DIR__ . '/BSONPolyfill.php');  //@codeCoverageIgnore
+        } elseif ( ! (function_exists('bson_decode') || function_exists('MongoDB\BSON\toPHP'))) {
+            throw new ParserException('Failed To Parse BSON - Supporting Library Not Available');  // @codeCoverageIgnore
         }
 
-        throw new ParserException('Failed To Parse BSON - Supporting Library Not Available');
+        if ($payload) {
+            $prevHandler = set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) {
+                throw new \Exception($errstr);  // @codeCoverageIgnore
+            });
+
+            try {
+                $bson = bson_decode(trim($payload, " \t\n\r\x0b"));  // Don't trim \0, as it has valid meaning in BSON
+                if ( ! $bson) {
+                    throw new \Exception('Unknown error');  // @codeCoverageIgnore
+                }
+            } catch (\Exception $e) {
+                set_error_handler($prevHandler);
+                throw new ParserException('Failed To Parse BSON - ' . $e->getMessage());
+            }
+
+            set_error_handler($prevHandler);
+
+            return $bson;
+        }
+
+        return [];
     }
 }

--- a/src/Formats/BSONPolyfill.php
+++ b/src/Formats/BSONPolyfill.php
@@ -1,0 +1,8 @@
+<?php
+
+if ( ! function_exists('bson_decode')) {
+    function bson_decode($payload)
+    {
+        return MongoDB\BSON\toPHP($payload, ['root' => 'array', 'document' => 'array']);
+    }
+}

--- a/src/Formats/FormatInterface.php
+++ b/src/Formats/FormatInterface.php
@@ -15,6 +15,9 @@ interface FormatInterface
      * Parse Payload Data
      *
      * @param string $payload
+     *
+     * @throws ParserException
+     *
      * @return array
      */
     public function parse($payload);

--- a/src/Formats/MSGPack.php
+++ b/src/Formats/MSGPack.php
@@ -19,22 +19,30 @@ class MSGPack implements FormatInterface
      * @param string $payload
      *
      * @throws ParserException
-     * @return array
      *
+     * @return array
      */
     public function parse($payload)
     {
         if (function_exists('msgpack_unpack')) {
             if ($payload) {
+                $prevHandler = set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) {
+                    throw new ParserException('Failed To Parse MSGPack');  // @codeCoverageIgnore
+                });
+
                 $msg = msgpack_unpack(trim($payload));
                 if ( ! $msg) {
-                    throw new ParserException('Failed To Parse MSGPack');
+                    set_error_handler($prevHandler);  // @codeCoverageIgnore
+                    throw new ParserException('Failed To Parse MSGPack');  // @codeCoverageIgnore
                 }
+
+                set_error_handler($prevHandler);
+
                 return $msg;
             }
             return [];
         }
 
-        throw new ParserException('Failed To Parse MSGPack - Supporting Library Not Available');
+        throw new ParserException('Failed To Parse MSGPack - Supporting Library Not Available');  // @codeCoverageIgnore
     }
 }

--- a/src/Formats/YAML.php
+++ b/src/Formats/YAML.php
@@ -3,6 +3,7 @@
 namespace Nathanmac\Utilities\Parser\Formats;
 
 use Nathanmac\Utilities\Parser\Exceptions\ParserException;
+use Symfony\Component\Yaml\Yaml as SFYaml;
 
 /**
  * YAML Formatter
@@ -26,7 +27,8 @@ class YAML implements FormatInterface
     {
         if ($payload) {
             try {
-                return \Symfony\Component\Yaml\Yaml::parse(trim(preg_replace('/\t+/', '', $payload)));
+                $flags = (defined('Symfony\Component\Yaml\Yaml::PARSE_DATETIME')) ? (SFYaml::PARSE_EXCEPTION_ON_INVALID_TYPE | SFYaml::PARSE_DATETIME) : true;
+                return SFYaml::parse(trim(preg_replace('/\t+/', '', $payload)), $flags);
             } catch (\Exception $ex) {
                 throw new ParserException('Failed To Parse YAML');
             }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -194,7 +194,7 @@ class Parser
     /**
      * Autodetect the payload data type using content-type value.
      *
-     * @return string Return the short format code (xml, json, ...).
+     * @return string Return the name of the formatter class.
      */
     public function getFormatClass($format = '')
     {

--- a/tests/BSONTest.php
+++ b/tests/BSONTest.php
@@ -9,10 +9,15 @@ class BSONTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function parser_validates_bson_data()
     {
-        if (function_exists('bson_decode')) {
-            $expected = ['status' => 123, 'message' => 'hello world'];
-            $payload  = bson_encode($expected);
+        $expected  = ['status' => 123, 'message' => 'hello world'];
 
+        if (function_exists('bson_encode')) {
+            $payload = bson_encode($expected);
+        } elseif (function_exists('MongoDB\BSON\fromPHP')) {
+            $payload = \MongoDB\BSON\fromPHP($expected);
+        }
+
+        if (function_exists('bson_decode') || function_exists('MongoDB\BSON\toPHP')) {
             $parser = new Parser();
             $this->assertEquals($expected, $parser->bson($payload));
         }
@@ -21,7 +26,7 @@ class BSONTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function parser_empty_bson_data()
     {
-        if (function_exists('bson_decode')) {
+        if (function_exists('bson_decode') || function_exists('MongoDB\BSON\toPHP')) {
             $parser = new Parser();
             $this->assertEquals([], $parser->bson(""));
         }
@@ -30,7 +35,7 @@ class BSONTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function throw_an_exception_when_bson_library_not_loaded()
     {
-        if ( ! function_exists('bson_decode')) {
+        if ( ! (function_exists('bson_decode') || function_exists('MongoDB\BSON\toPHP'))) {
             $this->setExpectedException('Exception', 'Failed To Parse BSON - Supporting Library Not Available');
 
             $parser = new Parser();
@@ -41,7 +46,7 @@ class BSONTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function throws_an_exception_when_parsed_bson_bad_data()
     {
-        if (function_exists('bson_decode')) {
+        if (function_exists('bson_decode') || function_exists('MongoDB\BSON\toPHP')) {
             $parser = new Parser();
             $this->setExpectedException('Exception', 'Failed To Parse BSON');
             $parser->bson('as|df>ASFBw924hg2=');
@@ -52,7 +57,7 @@ class BSONTest extends \PHPUnit_Framework_TestCase
     public function format_detection_bson()
     {
         $parser = new Parser();
-        
+
         $_SERVER['HTTP_CONTENT_TYPE'] = "application/bson";
         $this->assertEquals('Nathanmac\Utilities\Parser\Formats\BSON', $parser->getFormatClass());
 


### PR DESCRIPTION
Primarily updates for BSON and YAML (Mongo has been deprecated in favor of MongoDB, and Symfony YAML 3+ handles exception throwing differently than 2.x), but also includes a fix for MSGPack error handling.

- Added support for MongoDB extension (while keeping support for Mongo extension)
- Fixed error detection for MSGPack
- Fixed error detection for YAML, including support for pre-3.1 and post-3.1 differences
- Minor cleanup