### PR TITLE
Added XML Attribute and Namespace Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ $parsed = $parser->json('
 $parser = new Parser();
 $parsed = $parser->xml('
 			<?xml version="1.0" encoding="UTF-8"?>
-			<xml>
-				<message>
+			<xml xmlns:ns="http://example.com/xmlns">
+				<message status="sent">
+					<ns:meta hint="created">Created 5 minutes ago</ns:meta>
 					<to>Jack Smith</to>
 					<from>Jane Doe</from>
 					<subject>Hello World</subject>

--- a/src/Formats/MSGPack.php
+++ b/src/Formats/MSGPack.php
@@ -27,13 +27,17 @@ class MSGPack implements FormatInterface
         if (function_exists('msgpack_unpack')) {
             if ($payload) {
                 $prevHandler = set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) {
-                    throw new ParserException('Failed To Parse MSGPack');  // @codeCoverageIgnore
+                    throw new \Exception($errstr);  // @codeCoverageIgnore
                 });
 
-                $msg = msgpack_unpack(trim($payload));
-                if ( ! $msg) {
-                    set_error_handler($prevHandler);  // @codeCoverageIgnore
-                    throw new ParserException('Failed To Parse MSGPack');  // @codeCoverageIgnore
+                try {
+                    $msg = msgpack_unpack(trim($payload));
+                    if ( ! $msg) {
+                        throw new \Exception('Unknown error');  // @codeCoverageIgnore
+                    }
+                } catch (\Exception $e) {
+                    set_error_handler($prevHandler);
+                    throw new ParserException('Failed To Parse MSGPack - ' . $e->getMessage());
                 }
 
                 set_error_handler($prevHandler);

--- a/tests/XMLTest.php
+++ b/tests/XMLTest.php
@@ -60,6 +60,7 @@ class XMLTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['status' => 123, 'message' => 'hello world'], $parser->payload());
     }
+
     /** @test */
     public function parse_auto_detect_xml_data_define_content_type_as_param()
     {
@@ -79,6 +80,27 @@ class XMLTest extends \PHPUnit_Framework_TestCase
     {
         $parser = new Parser();
         $this->assertEquals(['status' => 123, 'message' => 'hello world'], $parser->xml("<?xml version=\"1.0\" encoding=\"UTF-8\"?><xml><status>123</status><message>hello world</message></xml>"));
+    }
+
+    /** @test */
+    public function parser_validates_xml_data_with_attribute()
+    {
+        $parser = new Parser();
+        $this->assertEquals(['status' => 123, 'message' => 'hello world', '@name' => 'root'], $parser->xml("<?xml version=\"1.0\" encoding=\"UTF-8\"?><xml name=\"root\"><status>123</status><message>hello world</message></xml>"));
+    }
+
+    /** @test */
+    public function parser_validates_xml_data_with_namespace()
+    {
+        $parser = new Parser();
+        $this->assertEquals(['status' => 123, 'ns:message' => 'hello world'], $parser->xml("<?xml version=\"1.0\" encoding=\"UTF-8\"?><xml xmlns:ns=\"data:namespace\"><status>123</status><ns:message>hello world</ns:message></xml>"));
+    }
+
+    /** @test */
+    public function parser_validates_xml_data_with_attribute_and_namespace()
+    {
+        $parser = new Parser();
+        $this->assertEquals(['status' => 123, 'ns:message' => 'hello world', '@name' => 'root'], $parser->xml("<?xml version=\"1.0\" encoding=\"UTF-8\"?><xml name=\"root\" xmlns:ns=\"data:namespace\"><status>123</status><ns:message>hello world</ns:message></xml>"));
     }
 
     /** @test */


### PR DESCRIPTION
- XML has extra properties on each key-value pair that the other encodings do not; this PR adds support for them in a manner compatible with nathanmac/Responder:
  - Attributes are parsed as "@name" => "value", which is consistent with how Responder determines how to render attributes.
  - Namespaces are kept intact by name ("ns:name" => "value"); at the moment, the namespace URIs are discarded.
- Added tests to ensure new feature is working properly.
- Also added fix for MSGPack formatter to properly reset error handler in all cases.