### PR TITLE
update documentation for providers and alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Include the service provider within `app/config/app.php`.
 
 ```php
 'providers' => [
-    '...',
-    'Nathanmac\Utilities\Parser\ParserServiceProvider'
+    ...,
+    Nathanmac\Utilities\Parser\ParserServiceProvider::class
 ];
 ```
 
@@ -44,8 +44,8 @@ And, for convenience, add a facade alias to this same file at the bottom:
 
 ```php
 'aliases' => [
-    '...',
-    'Parser' => 'Nathanmac\Utilities\Parser\Facades\Parser',
+    ...,
+    'Parser' => Nathanmac\Utilities\Parser\Facades\Parser::class,
 ];
 ```
 


### PR DESCRIPTION
provide class name using ::class instead of a string