### PR TITLE
Change installation instructions to prevent composer waring

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 
 Begin by installing this package through Composer. From the Terminal:
 
-    composer require nathanmac/Parser
+    composer require nathanmac/parser
 
 ### Laravel/Lumen Users
 


### PR DESCRIPTION
With the current composer version a waring is thrown when trying to install packages which aren't lowercase:
`Deprecation warning: require.nathanmac/Parser is invalid, it should not contain uppercase characters. Please use nathanmac/parser instead. Make sure you fix this as Composer 2.0 will error`
To make sure that the packe can be installed/updated with future composer versions, the instructions should contain the packe name in lowercase characters (so that it is added to the user's composer.json in the correct format).